### PR TITLE
Add jest as test script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "start": "yarn workspaces foreach -pi run start",
     "build": "yarn workspaces foreach -pti run build",
+    "test": "yarn workspaces foreach -pti run test",
     "start:server": "yarn workspace @ogfcommunity/variants-server run start",
     "start:client": "yarn workspace @ogfcommunity/variants-client run start",
     "start:shared": "yarn workspace @ogfcommunity/variants-shared run start"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "echo \"react-client tests not implemented\"",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "start": "nodemon ./src/index.ts",
     "launch": "tsc && node ./dist/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"No tests in packages/server.\""
   },
   "devDependencies": {
     "nodemon": "^2.0.19",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc",
     "start": "tsc --watch",
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "test": "jest"
   },
   "dependencies": {
     "typescript": "^4.7.4"


### PR DESCRIPTION
Specifies jest as the test command (at least for `/shared`).  this should fix the fact that the build is broken.

From the root of the repo you can now run `npm test` or `yarn test` and it will run jest for the shared repo, and any other test scripts we add in the future.