### PR TITLE
Let Git handle line endings (LF/CRLF) instead of ESLint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/packages/vue-client/.eslintrc.cjs
+++ b/packages/vue-client/.eslintrc.cjs
@@ -16,6 +16,6 @@ module.exports = {
     },
   ],
   rules: {
-    "prettier/prettier": "error",
+    "prettier/prettier": ["error", { endOfLine: "auto" }],
   },
 };


### PR DESCRIPTION
* Let Git "ensure that text files have their line endings normalized". (see https://www.git-scm.com/docs/gitattributes)
* Tell ESLint to "maintain existing line endings" via Prettier's `endOfLine: "auto"` option. (see https://prettier.io/docs/en/options.html)

Why?
Depending on their machine-wide Git settings Windows users might or might not use CRLF instead of LF when Git checks out files to their filesystem and Git might or might not change those CRLFs to LFs when checking in changes.
* Having ESLint interfere with that can cause lots of errors/warnings or lots of changes to files which Git recognizes as such.
* To avoid having CRLF line endings committed, we can tell Git to normalize the line endings for this repository via the `.gitattributes` file.

Caution:
`* text=auto` makes Git replace CRLF with LF for all files which Git *guesses* to be text files. If Git wrongfully guesses a binary file to be a text file it can damage the file by doing the replacement. If this causes troubles in the future we'd need to e.g. add
`*.ico -text` to `.gitattributes` to tell Git that files with certain file endings are known to be binary files.